### PR TITLE
Make SectionHeader and SectionHeaderFlags public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elf_rs"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Vincent Hou <vincent.houyi@gmail.com>"]
 edition = "2018"
 description = "A simple no_std ELF file reader for ELF32 and ELF64"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@ use elf::ElfGen;
 use elf_header::{ElfHeaderGen};
 
 pub use elf_header::{ElfAbi, ElfClass, ElfEndian, ElfMachine, ElfType};
-pub use program_header::{ProgramType};
-pub use section_header::{SectionType};
+pub use program_header::ProgramType;
+pub use section_header::{SectionHeader, SectionHeaderFlags, SectionType};
 
 type Elf32<'a> = elf::ElfGen<'a, u32>;
 type Elf64<'a> = elf::ElfGen<'a, u64>;


### PR DESCRIPTION
So a program loading ELF files can actually see the type of a section,
and use the flags to load section correctly.