### PR TITLE
Early check of header size if ELF64 is detected

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,9 @@ impl<'a> Elf<'a> {
         let tmp_elf = ElfGen::<u32>::new(elf_buf);
         match tmp_elf.header().class() {
             ElfClass::Elf64 => { 
+                if elf_buf.len() < size_of::<ElfHeaderGen<u64>>() {
+                    return Err(Error::BufferTooShort);
+                }
                 let elf = Elf64::new(elf_buf);
                 if elf_buf.len() < elf.header().elf_header_size() as usize {
                     Err(Error::BufferTooShort)


### PR DESCRIPTION
By feeding `Elf::from_bytes()` the first 52 bytes of a ELF64 header, it is possible to have the function read past the buffer given as parameter because the `ehsize` field is at a greater offset.

The bug has been found using `cargo fuzz` and can be demonstrated using the following base64 input to `Elf::from_bytes()` once
decoded:

```
f0VMRgL//zQACszMzcwrCgoKClkKCszMzcwrCgoKzAqmplpZWQooCkdZWf9GyQAAuLi4uA==
```