### PR TITLE
added type for program header flags

### DIFF
--- a/src/program_header/mod.rs
+++ b/src/program_header/mod.rs
@@ -12,6 +12,19 @@ const LOOS: u32 = 0x60000000;
 const HIOS: u32 = 0x6FFFFFFF;
 const LOPROC: u32 = 0x70000000;
 const HIPROC: u32 = 0x7FFFFFFF;
+
+bitflags! {
+    /// The flags of an ELF program header. Always 32 bit long, also
+    /// for 64-bit ELFs.
+    ///
+    /// Also called "Segment Permissions" in ELF specification or "p_flags".
+    pub struct ProgramHeaderFlags: u32 {
+        const EXECUTE = 1;
+        const WRITE = 2;
+        const READ = 4;
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ProgramType {
     NULL,                   // 0x00000000,
@@ -47,7 +60,7 @@ impl From<u32> for ProgramType {
 pub trait ProgramHeader {
     fn ph_type(&self) -> ProgramType;
 
-    fn flags(&self) -> u32;
+    fn flags(&self) -> ProgramHeaderFlags;
 
     fn offset(&self) -> u64;
 

--- a/src/program_header/program_header32.rs
+++ b/src/program_header/program_header32.rs
@@ -1,5 +1,5 @@
 use core::ptr::read_unaligned;
-use crate::program_header::{ProgramHeader, ProgramType};
+use crate::program_header::{ProgramHeader, ProgramHeaderFlags, ProgramType};
 
 #[derive(Debug)]
 #[repr(C)]
@@ -10,7 +10,7 @@ pub struct ProgramHeader32 {
     p_paddr: u32,
     p_filesz: u32,
     p_memsz: u32,
-    p_flags: u32,
+    p_flags: ProgramHeaderFlags,
     p_align: u32,
 }
 
@@ -21,7 +21,7 @@ impl ProgramHeader for ProgramHeader32 {
         }
     }
 
-    fn flags(&self) -> u32 {
+    fn flags(&self) -> ProgramHeaderFlags {
         unsafe {
             read_unaligned(&self.p_flags)
         }

--- a/src/program_header/program_header64.rs
+++ b/src/program_header/program_header64.rs
@@ -1,11 +1,11 @@
 use core::ptr::read_unaligned;
-use crate::program_header::{ProgramHeader, ProgramType};
+use crate::program_header::{ProgramHeader, ProgramHeaderFlags, ProgramType};
 
 #[derive(Debug)]
 #[repr(C)]
 pub struct ProgramHeader64 {
     p_type: u32,
-    p_flags: u32,
+    p_flags: ProgramHeaderFlags,
     p_offset: u64,
     p_vaddr: u64,
     p_paddr: u64,
@@ -21,7 +21,7 @@ impl ProgramHeader for ProgramHeader64 {
         }
     }
 
-    fn flags(&self) -> u32 {
+    fn flags(&self) -> ProgramHeaderFlags {
         unsafe {
             read_unaligned(&self.p_flags)
         }


### PR DESCRIPTION
This PR adds typings for program header flags (segment permissions) as defined in <https://refspecs.linuxfoundation.org/elf/elf.pdf>