### PR TITLE
fix: `ProgramHeader` was not exposed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,8 @@ pub use elf_header::{
     ElfAbi, ElfClass, ElfEndian, ElfHeader, ElfHeader32, ElfHeader64, ElfMachine, ElfType,
 };
 pub use program_header::{
-    ProgramHeader32, ProgramHeader64, ProgramHeaderFlags, ProgramHeaderIter, ProgramHeaderWrapper,
-    ProgramType,
+    ProgramHeader, ProgramHeader32, ProgramHeader64, ProgramHeaderFlags, ProgramHeaderIter,
+    ProgramHeaderWrapper, ProgramType,
 };
 pub use section_header::{
     SectionHeader, SectionHeader32, SectionHeader64, SectionHeaderFlags, SectionHeaderIter,


### PR DESCRIPTION
This type is necessary to call methods like
`ProgramHeaderWrapper::deref`.
