### PR TITLE
update bitflags dependency to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ license-file = "LICENSE"
 travis-ci = { repository = "vincenthouyi/elf_rs", branch = "master" }
 
 [dependencies]
-bitflags = "1.3"
+bitflags = "2.4"
 num-traits = { version = "0.2", default-features = false }

--- a/src/program_header/mod.rs
+++ b/src/program_header/mod.rs
@@ -14,6 +14,7 @@ bitflags! {
     /// for 64-bit ELFs.
     ///
     /// Also called "Segment Permissions" in ELF specification or "p_flags".
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub struct ProgramHeaderFlags: u32 {
         const EXECUTE = 1;
         const WRITE = 2;

--- a/src/section_header/mod.rs
+++ b/src/section_header/mod.rs
@@ -64,6 +64,7 @@ impl From<u32> for SectionType {
 }
 
 bitflags! {
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub struct SectionHeaderFlags: u64 {
         const SHF_WRITE             = 0x1;
         const SHF_ALLOC             = 0x2;


### PR DESCRIPTION
Because of this update we also need to derive Debug on ProgramHeaderFlags and SectionHeaderFlags.